### PR TITLE
add 0 at end of string lower in zutil.c function is_img

### DIFF
--- a/zutil.c
+++ b/zutil.c
@@ -152,7 +152,7 @@ int is_img(const char *filename)
     char *tmp;
     int i;
     int isimg = 0;
-    for(i = 0; i < strlen(filename); i++)
+    for(i = 0; filename[i]; i++)
     {
         lower[i] = tolower(filename[i]);
     }


### PR DESCRIPTION
hi~
filename 转换到 lower 之后 lower 末尾没有加 '\0'，测试了一些扩展名功能没有问题，但是通常 lower 是一个 "jpg\354\377\177" 形式的字符串了。

```
for(i = 0; i < strlen(filename); i++)
{
    lower[i] = tolower(filename[i]);
}
lower[strlen(filename)] = '\0';
```

或者这样改？：）
