### PR TITLE
add 0 at end of string lower in zutil.c function is_img

### DIFF
--- a/zutil.c
+++ b/zutil.c
@@ -156,6 +156,7 @@ int is_img(const char *filename)
     {
         lower[i] = tolower(filename[i]);
     }
+    lower[strlen(filename)] = '\0';
     for(i = 0; i < 4; i++)
     {
         LOG_PRINT(LOG_INFO, "compare %s - %s.", lower, imgType[i]);


### PR DESCRIPTION
hi~
filename 转换到 lower 之后 lower 末尾没有加 '\0'，测试了一些扩展名功能没有问题，但是通常 lower 是一个 "jpg\354\377\177" 形式的字符串了。

之前第一次提交的pr 是错误的 ：） https://github.com/buaazp/zimg/pull/3
