### PR TITLE
可以上传和下载非图片文件

### DIFF
--- a/src/url.c
+++ b/src/url.c
@@ -1,0 +1,97 @@
+    #include <stdlib.h>  
+    #include <string.h>  
+    #include <ctype.h>  
+    #include <sys/types.h>  
+      
+    #include "url.h"  
+      
+    static unsigned char hexchars[] = "0123456789ABCDEF";  
+      
+    static int zimg_htoi(char *s)  
+    {  
+        int value;  
+        int c;  
+      
+        c = ((unsigned char *)s)[0];  
+        if (isupper(c))  
+            c = tolower(c);  
+        value = (c >= '0' && c <= '9' ? c - '0' : c - 'a' + 10) * 16;  
+      
+        c = ((unsigned char *)s)[1];  
+        if (isupper(c))  
+            c = tolower(c);  
+        value += c >= '0' && c <= '9' ? c - '0' : c - 'a' + 10;  
+      
+        return (value);  
+    }  
+      
+      
+    char *zimg_url_encode(char const *s, int len, int *new_length)  
+    {  
+        register unsigned char c;  
+        unsigned char *to, *start;  
+        unsigned char const *from, *end;  
+          
+        from = (unsigned char *)s;  
+        end  = (unsigned char *)s + len;  
+        start = to = (unsigned char *) calloc(1, 3*len+1);  
+      
+        while (from < end)   
+        {  
+            c = *from++;  
+      
+            if (c == ' ')   
+            {  
+                *to++ = '+';  
+            }   
+            else if ((c < '0' && c != '-' && c != '.') ||  
+                     (c < 'A' && c > '9') ||  
+                     (c > 'Z' && c < 'a' && c != '_') ||  
+                     (c > 'z'))   
+            {  
+                to[0] = '%';  
+                to[1] = hexchars[c >> 4];  
+                to[2] = hexchars[c & 15];  
+                to += 3;  
+            }  
+            else   
+            {  
+                *to++ = c;  
+            }  
+        }  
+        *to = 0;  
+        if (new_length)   
+        {  
+            *new_length = to - start;  
+        }  
+        return (char *) start;  
+    }  
+      
+      
+    int zimg_url_decode(char *str, int len)  
+    {  
+        char *dest = str;  
+        char *data = str;  
+      
+        while (len--)   
+        {  
+            if (*data == '+')   
+            {  
+                *dest = ' ';  
+            }  
+            else if (*data == '%' && len >= 2 && isxdigit((int) *(data + 1)) && isxdigit((int) *(data + 2)))   
+            {  
+                *dest = (char) zimg_htoi(data + 1);  
+                data += 2;  
+                len -= 2;  
+            }   
+            else   
+            {  
+                *dest = *data;  
+            }  
+            data++;  
+            dest++;  
+        }
+        *dest = '\0';  
+        return dest - str;  
+    }

--- a/src/url.h
+++ b/src/url.h
@@ -1,0 +1,15 @@
+#ifndef URL_H  
+#define URL_H  
+
+#ifdef __cplusplus  
+extern "C" {  
+#endif  
+
+int zimg_url_decode(char *str, int len);  
+char *zimg_url_encode(char const *s, int len, int *new_length);  
+
+#ifdef __cplusplus  
+}  
+#endif  
+
+#endif /* URL_H */  

--- a/src/zcommon.h
+++ b/src/zcommon.h
@@ -65,6 +65,7 @@ typedef struct zimg_req_s {
     char *fmt;
     int sv;
     thr_arg_t *thr_arg;
+    char file_schema[1024];
 } zimg_req_t;
 
 struct setting{
@@ -92,7 +93,6 @@ struct setting{
     char admin_path[512];
     int disable_args;
     int disable_type;
-    int disable_zoom_up;
     int script_on;
     char script_name[512];
     char format[16];

--- a/src/zimg.c
+++ b/src/zimg.c
@@ -164,7 +164,7 @@ int new_img(const char *buff, const size_t len, const char *save_name, const cha
     snprintf(schema_name,sizeof(schema_name)-1,"%s_schema",save_name);
     LOG_PRINT(LOG_DEBUG, "schema_name is :%s ", schema_name);
 
-    if ( strlen(origin_file_name) > 0 )
+    if ( origin_file_name && strlen(origin_file_name) > 0 )
     {
         cJSON *j_ret = cJSON_CreateObject();
         cJSON_AddStringToObject(j_ret, "filename", origin_file_name);
@@ -269,6 +269,7 @@ int get_img(zimg_req_t *req, evhtp_request_t *request)
     char schema_path[512];
     snprintf(schema_path, 512, "%s/0*0_schema", whole_path);
     LOG_PRINT(LOG_DEBUG, "Schema File Path: %s", schema_path);
+    memset(req->file_schema,0,1024);
     FILE *fp = fopen(schema_path,"r");
     if ( fp != NULL )
     {

--- a/src/zimg.h
+++ b/src/zimg.h
@@ -23,8 +23,8 @@
 
 #include "zcommon.h"
 
-int save_img(thr_arg_t *thr_arg, const char *buff, const int len, char *md5);
-int new_img(const char *buff, const size_t len, const char *save_name);
+int save_img(thr_arg_t *thr_arg, const char *origin_file_name, const char *buff, const int len, char *md5);
+int new_img(const char *buff, const size_t len, const char *save_name, const char *origin_file_name);
 int get_img(zimg_req_t *req, evhtp_request_t *request);
 int admin_img(evhtp_request_t *req, thr_arg_t *thr_arg, char *md5, int t);
 int info_img(evhtp_request_t *request, thr_arg_t *thr_arg, char *md5);


### PR DESCRIPTION
能够支持非图片文件的上传和下载， 
 zimg.lua中做2处修改：
1. format          = 'jpeg' 改为  format          = 'none'
2. allowed_type改为 allowed_type    = {'image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp', 'application/zip', 'application/pdf', 'application/msword', 'application/.docx', 'application/octet-stream'}  
上传时http头中加 zimg-filename:文件名  , 
例如: zimg-filename:a.pdf  
下载非图片文件时需要加p=0参数  
上传示例: 
curl -H "Content-Type:application/octet-stream" -H "zimg-filename:a.pdf" --data-binary @a.pdf "http://localhost:4869" 
下载示例：
curl "http://localhost:4869/5b43fa8518caa20cce5fea551228d7a3?p=0" > b.pdf 
在浏览器中输入文件对应的url地址后，会弹出下载框提示下载文件，默认的文件名就是zimg-filename指定的文件名。
例如：
http://localhost:4869/5b43fa8518caa20cce5fea551228d7a3?p=0
