### PR TITLE
增加redis支持密码授权和选择数据库索引配置功能

### DIFF
--- a/bin/conf/zimg.lua
+++ b/bin/conf/zimg.lua
@@ -52,7 +52,7 @@ LOG_INFO 6      Information
 LOG_DEBUG 7     DEBUG message
 ]]
 --输出log级别
-log_level       = 6
+log_level       = 7 
 --输出log路径
 log_name        = pwd .. '/log/zimg.log'
 
@@ -85,7 +85,7 @@ quality         = 75
 --value 2 is for memcached protocol storage like beansdb;
 --value 3 is for redis protocol storage like SSDB.
 --存储后端类型，1为本地存储，2为memcached协议后端如beansdb，3为redis协议后端如SSDB
-mode            = 1
+mode            = 3
 --save_new value: 0.don't save any 1.save all 2.only save types in lua script
 --新文件是否存储，0为不存储，1为全都存储，2为只存储lua脚本产生的新图
 save_new        = 1
@@ -106,9 +106,13 @@ beansdb_port    = 7900
 
 --mode[3]: ssdb mode
 --SSDB服务器IP
-ssdb_ip         = '127.0.0.1'
+ssdb_ip         = 'redis1.5upay.lan'
 --SSDB服务器端口
-ssdb_port       = 8888
+ssdb_port       = 6379
+--
+ssdb_passwd     = 'GOft2zRX6'
+--
+ssdb_index      = 6
 
 --lua conf functions
 --部分与配置有关的函数在lua中实现，对性能影响不大

--- a/bin/conf/zimg.lua
+++ b/bin/conf/zimg.lua
@@ -109,9 +109,9 @@ beansdb_port    = 7900
 ssdb_ip         = '127.0.0.1'
 --SSDB服务器端口
 ssdb_port       = 8888
---
+--授权密码
 ssdb_passwd     = ''
---
+--数据库索引
 ssdb_index      = 0
 
 --lua conf functions

--- a/bin/conf/zimg.lua
+++ b/bin/conf/zimg.lua
@@ -52,7 +52,7 @@ LOG_INFO 6      Information
 LOG_DEBUG 7     DEBUG message
 ]]
 --输出log级别
-log_level       = 7 
+log_level       = 6 
 --输出log路径
 log_name        = pwd .. '/log/zimg.log'
 
@@ -85,7 +85,7 @@ quality         = 75
 --value 2 is for memcached protocol storage like beansdb;
 --value 3 is for redis protocol storage like SSDB.
 --存储后端类型，1为本地存储，2为memcached协议后端如beansdb，3为redis协议后端如SSDB
-mode            = 3
+mode            = 1
 --save_new value: 0.don't save any 1.save all 2.only save types in lua script
 --新文件是否存储，0为不存储，1为全都存储，2为只存储lua脚本产生的新图
 save_new        = 1
@@ -106,13 +106,13 @@ beansdb_port    = 7900
 
 --mode[3]: ssdb mode
 --SSDB服务器IP
-ssdb_ip         = 'redis1.5upay.lan'
+ssdb_ip         = '127.0.0.1'
 --SSDB服务器端口
-ssdb_port       = 6379
+ssdb_port       = 8888
 --
-ssdb_passwd     = 'GOft2zRX6'
+ssdb_passwd     = ''
 --
-ssdb_index      = 6
+ssdb_index      = 0
 
 --lua conf functions
 --部分与配置有关的函数在lua中实现，对性能影响不大

--- a/bin/conf/zimg.lua
+++ b/bin/conf/zimg.lua
@@ -52,7 +52,7 @@ LOG_INFO 6      Information
 LOG_DEBUG 7     DEBUG message
 ]]
 --输出log级别
-log_level       = 6 
+log_level       = 6
 --输出log路径
 log_name        = pwd .. '/log/zimg.log'
 

--- a/src/zcommon.h
+++ b/src/zcommon.h
@@ -105,6 +105,8 @@ struct setting {
     int beansdb_port;
     char ssdb_ip[128];
     int ssdb_port;
+    char ssdb_passwd[256];
+    int ssdb_index;
     multipart_parser_settings *mp_set;
     int (*get_img)(zimg_req_t *, evhtp_request_t *);
     int (*info_img)(evhtp_request_t *, thr_arg_t *, char *);


### PR DESCRIPTION
1、zcommon.h 在settings数据结构里增加 ssdb_passwd,ssdb_index成员属性;
2、main.c  settings.init初始化ssdb_passwd,ssdb_index；load_conf读取配置赋值到ssdb_passwd,ssdb_index；增加createRedisContext方法；替换两处调用redisConnect为createRedisContext；
3、zimg.lua 增加 ssdb_passwd,ssdb_index 两项配置；