### PR TITLE
when batch delete file, if the number of files delete bigger than sys…

### DIFF
--- a/src/zutil.c
+++ b/src/zutil.c
@@ -462,6 +462,7 @@ int delete_file(const char *path) {
             if (ret == -1)
                 break;
         }
+        closedir(dir);
         if (ret == 1)
             ret = rmdir(path);
     }


### PR DESCRIPTION
fix issue. when batch delete file, if the number of files delete bigger than system allows，zimg will not work will，all request will return 404
detail see : https://github.com/buaazp/zimg/issues/280